### PR TITLE
Set to List optimization; This stores the QueryField collection in a …

### DIFF
--- a/fflib/src/classes/fflib_QueryFactory.cls
+++ b/fflib/src/classes/fflib_QueryFactory.cls
@@ -61,7 +61,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	**/
 	public Schema.SObjectType table {get; private set;}
 	@testVisible
-	private Set<QueryField> fields; 
+	private List<QueryField> fields; 
 	private String conditionExpression;
 	private Integer limitCount;
 	private Integer offset;
@@ -138,7 +138,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	**/
 	public fflib_QueryFactory(Schema.SObjectType table){
 		this.table = table;
-		fields = new Set<QueryField>();
+		fields = new List<QueryField>();
 		order = new List<Ordering>();
 		enforceFLS = false;
 	}
@@ -215,7 +215,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	**/
 	public fflib_QueryFactory selectFields(Set<String> fieldNames){
 		List<String> fieldList = new List<String>();
-		Set<QueryField> toAdd = new Set<QueryField>();
+		List<QueryField> toAdd = new List<QueryField>();
 		for(String fieldName:fieldNames){
 			toAdd.add( getFieldToken(fieldName) );
 		}	
@@ -227,7 +227,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @param fieldNames the List of field API names to select.
 	**/
 	public fflib_QueryFactory selectFields(List<String> fieldNames){
-		Set<QueryField> toAdd = new Set<QueryField>();
+		List<QueryField> toAdd = new List<QueryField>();
 		for(String fieldName:fieldNames)
 			toAdd.add( getFieldToken(fieldName) );
 		fields.addAll(toAdd);
@@ -326,12 +326,20 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	}
 
 	/**
+	 * @deprecated  Replaced by {@link #getSelectedFieldsAsList()}
 	 * @returns the selected fields
 	 **/
 	public Set<QueryField> getSelectedFields() { 
+		return new Set<QueryField>(this.fields);
+	}
+	
+	/**
+	 * @returns the selected fields as a List<QueryField>
+	 **/
+	public List<QueryField> getSelectedFieldsAsList() {
 		return this.fields;
 	}
-
+	
 	/**
 	 * Add a subquery query to this query.  If a subquery for this relationship already exists, it will be returned.
 	 * If not, a new one will be created and returned.
@@ -557,8 +565,13 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		}else if(sortSelectFields){
 			List<QueryField> fieldsToQuery = new List<QueryField>(fields);
 			fieldsToQuery.sort(); //delegates to QueryFilter's comparable implementation
+			// Now that the QueryField list is sorted, we can de-dupe
+			QueryField previousQf = null;
 			for(QueryField field:fieldsToQuery){
-				result += field + ', ';
+				if (!field.equals(previousQf)) {
+					result += field + ', ';
+				}
+				previousQf = field;
 			}
 		}else{
 			for (QueryField field : fields)

--- a/fflib/src/classes/fflib_QueryFactory.cls
+++ b/fflib/src/classes/fflib_QueryFactory.cls
@@ -214,12 +214,9 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @param fieldNames the Set of field API names to select.
 	**/
 	public fflib_QueryFactory selectFields(Set<String> fieldNames){
-		List<String> fieldList = new List<String>();
-		List<QueryField> toAdd = new List<QueryField>();
 		for(String fieldName:fieldNames){
-			toAdd.add( getFieldToken(fieldName) );
-		}	
-		fields.addAll(toAdd);
+			this.fields.add( getFieldToken(fieldName) );
+		}
 		return this;
 	}
 	/**
@@ -227,10 +224,8 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @param fieldNames the List of field API names to select.
 	**/
 	public fflib_QueryFactory selectFields(List<String> fieldNames){
-		List<QueryField> toAdd = new List<QueryField>();
 		for(String fieldName:fieldNames)
-			toAdd.add( getFieldToken(fieldName) );
-		fields.addAll(toAdd);
+			this.fields.add( getFieldToken(fieldName) );
 		return this;
 	}
 	/**

--- a/fflib/src/classes/fflib_QueryFactoryTest.cls
+++ b/fflib/src/classes/fflib_QueryFactoryTest.cls
@@ -67,6 +67,10 @@ private class fflib_QueryFactoryTest {
 		qf.selectField('NAMe').selectFields( new Set<String>{'naMe', 'email'});
 		String query = qf.toSOQL();
 		System.assertEquals(1, query.countMatches('Name'), 'Expected one name field in query: '+query );
+		// Try again with sortSelectFields set to false. No de-duplication will be performed, so we should have two Name fields.
+		qf.setSortSelectFields(false);
+		query = qf.toSOQL();
+		System.assertEquals(2, query.countMatches('Name'), 'Expected two name fields in query: '+query );
 	}
 
 	@isTest
@@ -78,7 +82,8 @@ private class fflib_QueryFactoryTest {
 		System.assertNotEquals(qf1,qf2);
 		qf2.selectField('NAmE');
 		System.assertEquals(qf1,qf2);
-		qf1.selectField('name').selectFields( new Set<String>{ 'NAME', 'name' }).selectFields( new Set<Schema.SObjectField>{ Contact.Name, Contact.Name} );
+		qf1.selectFields( new Set<String>{ 'NAME' });
+		qf2.selectFields( new Set<Schema.SObjectField>{ Contact.Name} );
 		System.assertEquals(qf1,qf2);
 	}
 


### PR DESCRIPTION
…List, as opposed to a Set to avoid performance problems caused Salesforce's shitty Set and Map implementations that are affected by debug log level settings. Duplicate fields are now allowed in the internal List<QueryField> collection, so I had to re-work a couple of unit tests to account for the possibility of dupe QueryField elements in the list. The toSOQL method will de-dupe the generated if (and only if) fflib_QueryFactory.sortSelectedFields is true. 
